### PR TITLE
manifest: nrf_modem: version 1.5.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -33,6 +33,9 @@ manifest:
       url-base: https://github.com/NordicSemiconductor
     - name: memfault
       url-base: https://github.com/memfault
+    - name: eivindj-nordic
+      url-base: https://github.com/eivindj-nordic
+
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -52,7 +55,8 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a49c0691993ce87d0a8216bd7a6cd8df9cd39941
+      remote: eivindj-nordic
+      revision: pull/8/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -108,7 +112,8 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: dc800f908e8c0e5ac2407f7dd4fcd19c64e1eb44
+      remote: eivindj-nordic
+      revision: pull/9/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update manifest for nrf_modem v1.5.2 release.

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>
Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>
